### PR TITLE
Create npm-publish-github-packages.yml

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the testing and publishing of a Node.js package to GitHub Packages upon the creation of a release. The key changes include defining the workflow, specifying the trigger event, and detailing the steps for building, testing, and publishing the package.

New GitHub Actions workflow:

* [`.github/workflows/npm-publish-github-packages.yml`](diffhunk://#diff-8278f114fcdc2cabbbcd45a250368d038f1792dc63f0e49abf52c46cffd57223R1-R36): Added a workflow that runs tests using Node.js and publishes a package to GitHub Packages when a release is created. The workflow includes steps for checking out the code, setting up Node.js, running tests, and publishing the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automated workflow that runs tests and seamlessly publishes the package upon release, ensuring a more reliable and streamlined delivery process for our end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->